### PR TITLE
Support nested decorating and fixes markup highlighting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 var Immutable = require('immutable');
 var Prism = require('prismjs');
+var htmlEncode = require('js-htmlencode').htmlEncode;
 
 var PrismOptions = require('./options');
 
@@ -22,6 +23,11 @@ PrismDecorator.prototype.getDecorations = function(block) {
     var getSyntax = this.options.get('getSyntax');
     var blockKey = block.getKey();
     var blockText = block.getText();
+
+    if (syntax === 'markup') {
+        blockText = htmlEncode(blockText);
+    }
+
     var decorations = Array(blockText.length).fill(null);
 
     this.highlighted[blockKey] = {};
@@ -39,26 +45,14 @@ PrismDecorator.prototype.getDecorations = function(block) {
 
     // Parse text using Prism
     var grammar = Prism.languages[syntax];
+
     tokens = Prism.tokenize(blockText, grammar);
 
-    for (var i =0; i < tokens.length; i++) {
-        token = tokens[i];
-
-        if (typeof token === 'string') {
-            offset += token.length;
-        } else {
-            tokenId = 'tok'+offset;
-            resultId = blockKey + '-' + tokenId;
-
-            this.highlighted[blockKey][tokenId] = token;
-
-            occupySlice(decorations, offset, offset + token.content.length, resultId);
-            offset += token.content.length;
-        }
-    }
+    this.buildDecorations(decorations, tokens, offset, blockKey);
 
     return Immutable.List(decorations);
 };
+
 
 /**
  * Return component to render a decoration
@@ -77,7 +71,7 @@ PrismDecorator.prototype.getComponentForKey = function(key) {
  * @return {Object}
  */
 PrismDecorator.prototype.getPropsForKey = function(key) {
-    var parts = key.split('-');
+    var parts = key.split('/');
     var blockKey = parts[0];
     var tokId = parts[1];
     var token = this.highlighted[blockKey][tokId];
@@ -87,9 +81,56 @@ PrismDecorator.prototype.getPropsForKey = function(key) {
     };
 };
 
+/**
+ * Builds the decorations array
+ *
+ * @param {List<String>} the initial decorations array
+ * @param {List<Object|String>}
+ * @param {Number}
+ * @param {String}
+ * @return {Number}
+ */
+PrismDecorator.prototype.buildDecorations = function(decorations, tokens, offset, blockKey) {
+    var token = tokens[0];
+
+    if (typeof token === 'string') {
+        offset += token.length;
+    } else {
+        var tokenId = token.type+offset;
+        var resultId = blockKey + '/' + tokenId;
+
+        var start = offset;
+        if (typeof token.content === 'string') {
+            this.highlighted[blockKey][tokenId] = token;
+            offset += token.content.length;
+            occupySlice(decorations, start, offset, resultId);
+        } else {
+            this.highlighted[blockKey][tokenId] = token;
+            offset = this.buildDecorations(decorations, token.content, offset, blockKey);
+          if (token.content.length > 1) {
+              replaceSlice(decorations, start, offset, resultId, null);
+          } else {
+              occupySlice(decorations, start, offset, resultId);
+          }
+        }
+    }
+
+    if (tokens.length > 1) {
+        return this.buildDecorations(decorations, tokens.slice(1, tokens.length), offset, blockKey);
+    }
+
+    return offset;
+};
+
 function occupySlice(targetArr, start, end, componentKey) {
     for (var ii = start; ii < end; ii++) {
         targetArr[ii] = componentKey;
+    }
+}
+
+function replaceSlice(targetArr, start, end, componentKey, replaceKey) {
+    for (var ii = start; ii < end; ii++) {
+        if(targetArr[ii] === replaceKey) targetArr[ii] = componentKey;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "extend": "^3.0.0",
     "immutable": "*",
+    "js-htmlencode": "^0.2.0",
     "prismjs": "^1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR supports nested decorating in order to solve issues with syntax that depends on that, such us `markup`. At the same time it encodes `markup` string before using it for solving an error that unable us to see html highlightning.